### PR TITLE
Adds a bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "backbone-fsm",
+  "version": "0.0.1",
+  "homepage": "https://github.com/fragphace/backbone-fsm.git",
+  "authors": [
+    "fragphace"
+  ],
+  "description": "Finite-State Machine for Backbone views and models.",
+  "main": "lib/backbone-fsm.js",
+  "keywords": [
+    "backbone",
+    "Finite-state machine",
+    "FSM"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I've registered this package pointing to my fork on the [Bower](http://bower.io/) package manager. I'd be happy to update it to point to your fork instead if you care to merge this PR.

`backbone-fsm@0.0.1` can now be installed like `bower install backbone-fsm`.
